### PR TITLE
fix: skip flat keys in namespaces and update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ heck = "0.5"  # For case conversion (camelCase, snake_case, etc.)
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 tokio = { version = "1.36", features = ["rt", "rt-multi-thread", "macros", "fs"] }
 thiserror = "1.0"
+rustls-webpki = "0.103.13"
+rand = "0.9.4"
 
 [dev-dependencies]
 tempfile = "3.10"
@@ -51,6 +53,7 @@ criterion = "0.5"
 mockito = "1.4"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
+rand_08 = { package = "rand", version = "0.8.6" }
 
 [[bench]]
 name = "performance_bench"

--- a/src/generator/luau.rs
+++ b/src/generator/luau.rs
@@ -562,6 +562,9 @@ fn generate_namespace_structure(code: &mut String, translations: &[&Translation]
 
     for translation in &regular_translations {
         let parts: Vec<&str> = translation.key.split('.').collect();
+        if parts.len() <= 1 {
+            continue;
+        }
         let namespace = sanitize_namespace_path(&parts[0..parts.len() - 1].join("."));
         let method = sanitize_segment(parts[parts.len() - 1]);
         let flat_method = sanitize_luau_identifier(&translation.key);
@@ -586,6 +589,9 @@ fn generate_namespace_structure(code: &mut String, translations: &[&Translation]
 
     for base_key in &plural_keys_sorted {
         let parts: Vec<&str> = base_key.split('.').collect();
+        if parts.len() <= 1 {
+            continue;
+        }
         let namespace = sanitize_namespace_path(&parts[0..parts.len() - 1].join("."));
         let method = sanitize_segment(parts[parts.len() - 1]);
         let flat_method = sanitize_luau_identifier(base_key);


### PR DESCRIPTION
## Summary

Skips flat keys in namespace structure generation and enforces secure dependency versions.

## Details

- Skips translation keys without dots to avoid generating invalid `self..key` Luau syntax.
- Pins secure versions of `rustls-webpki` and `rand` in `Cargo.toml`.

## Related Issues

None.

## How to Validate

Run `cargo test`.

## Pre-Merge Checklist

- [x] Added/updated tests (if needed)